### PR TITLE
Angel infinite ore fix. Bob's steam SP fix.

### DIFF
--- a/omnimatter/data-final-fixes.lua
+++ b/omnimatter/data-final-fixes.lua
@@ -122,12 +122,11 @@ for _,tier in pairs(omnisource) do
 			if gen.minable.result == ore.name then
 				data.raw.resource[gen.name] = nil
 				data.raw["autoplace-control"][gen.name] = nil
-				--return
 			elseif gen.minable.results  then
 				for _,res in pairs(gen.minable.results) do
 					if res.name == ore.name then
 						data.raw.resource[gen.name] = nil
-						data.raw["autoplace-control"][gen.name] = nil			
+						data.raw["autoplace-control"][gen.name] = nil
 					end
 				end
 			end
@@ -137,6 +136,7 @@ for _,tier in pairs(omnisource) do
 				if pre.basic_settings.autoplace_controls then
 					pre.basic_settings.autoplace_controls[ore.name] = nil
 					pre.basic_settings.autoplace_controls["sulfur"] = nil
+					pre.basic_settings.autoplace_controls["infinite-"..ore.name] = nil
 				end
 			end
 		end

--- a/omnimatter/data-final-fixes.lua
+++ b/omnimatter/data-final-fixes.lua
@@ -221,6 +221,15 @@ end
 
 RecGen:import("coal-liquefaction"):replaceIngredients("heavy-oil","omniston"):replaceIngredients("liquid-naphtha","omniston"):extend()
 
+if mods["bobtech"] and settings.startup["bobmods-burnerphase"] then
+	new_ingredients =
+    {
+      {"omnite", 1},
+      {"stone", 1},
+    }
+	data.raw.recipe["steam-science-pack"].ingredients = new_ingredients
+end
+
 --log("zombiee why more ideas?")
 
 --data.raw.technology["coal-liquefaction"]=nil

--- a/omnimatter/info.json
+++ b/omnimatter/info.json
@@ -5,5 +5,5 @@
 "author":"EmperorZelos",
 "description":"This mod condenses all ores into a single ore from which everything is extracted.",
 "factorio_version":"0.18",
-"dependencies":["base","? bobores","?angelspetrochem","?only-smelting","?angelsrefining","?Flare Stack","omnilib >= 3.0.0","?angelssmelting"]
+"dependencies":["base","? bobores","?angelspetrochem","?only-smelting","?angelsrefining","?Flare Stack","?bobtech","omnilib >= 3.0.0","?angelssmelting"]
 }


### PR DESCRIPTION
Fixes the crash on load issue when combined with Angel's infinite ores. #9 
Also fixes the issue with not being able to craft Steam SP with Bob's tech enabled.