### PR TITLE
Omniblocks

### DIFF
--- a/omnilib/locale/en/en.cfg
+++ b/omnilib/locale/en/en.cfg
@@ -3,12 +3,30 @@ omni-fluid=__1__
 
 [item-name]
 omni-item=__1__
+block-omni-0=Omni Block 0
+block-omni-1=Omni Block 1
+block-omni-2=Omni Block 2
+block-omni-3=Omni Block 3
+block-omni-4=Omni Block 4
+block-omni-5=Omni Block 5
 
 [recipe-name]
 omni-recipe=__1__
+block-omni-0=Omni Block 0
+block-omni-1=Omni Block 1
+block-omni-2=Omni Block 2
+block-omni-3=Omni Block 3
+block-omni-4=Omni Block 4
+block-omni-5=Omni Block 5
 
 [technology-name]
 omni-tech=__1__
 
 [message]
 omni-difficulty=[Omnimatter] IMPORTANT! If the game is too difficult, slow, fast or easy, then change the many mod settings to fit your desire, there are plenty of options! They act retroactively.
+
+[mod-setting-name]
+omnilib-autoupdate=Autorun Omnilib scripts.
+
+[mod-setting-description]
+omnilib-autoupdate=Autorun Omnilib scripts on mapload.

--- a/omnilib/prototypes/ingredients-generation.lua
+++ b/omnilib/prototypes/ingredients-generation.lua
@@ -33,18 +33,6 @@ component["bob-gear-box"] = {"omnicium-iron-gear-box","omnicium-steel-gear-box",
 component["angels-gear-box"] = {"omnicium-iron-gear-box","omnicium-steel-gear-box","omnicium-titanium-gear-box","omnicium-tungsten-gear-box"}
 component["bearing"]={"steel-bearing", nil, "cobalt-steel-bearing", "titanium-bearing", "nitinol-bearing", "ceramic-bearing"}
 
-if mods["angelsindustries"] and angelsmods.industries.components then
-	-- DEFINE BLOCKS
-	component["construction-block"] = {"block-construction-1", "block-construction-2", "block-construction-3", "block-construction-4","block-construction-5"}
-	component["electric-block"] = {"block-electronics-1", "block-electronics-2", "block-electronics-3", "block-electronics-4", "block-electronics-5"}
-	component["fluid-block"] = {"construction-frame-1", "block-fluidbox-1", nil, "block-fluidbox-2", nil}
-	component["mechanical-block"] = {"construction-frame-1", "block-mechanical-1", nil, "block-mechanical-2", nil}
-	component["enhancement-block"] = {"block-enhancement-1", "block-enhancement-2", "block-enhancement-3", "block-enhancement-4", "block-enhancement-5"}
-	component["energy-block"] = {"block-energy-1", "block-energy-2", "block-energy-3", "block-energy-4", "block-energy-5"}
-	component["logistic-block"] = {"block-logistic-1", "block-logistic-2", "block-logistic-3", "block-logistic-4", "block-logistic-5"}
-	component["production-block"] = {"block-production-1", "block-production-2", "block-production-3", "block-production-4", "block-production-5"}
-end
-
 --------------------------------------------------------------------------------------------------
 -- Component list swapping logic -----------------------------------------------------------------
 --------------------------------------------------------------------------------------------------
@@ -111,6 +99,20 @@ end
 --AUTO GROUP SWITCHES
 local cmpn = {"vanilla-circuit","crystallonics","vanilla-gear-wheel","bob-gear-wheel","vanilla-gear-box","bob-gear-box","plate","bob-plate","angel-plate","angel-bob-plate","angels-gear-wheel","omni-bob-alloys",
 "omni-plate","vanilla-pipe","bob-pipe","bob-logistics","bob-circuit","omni-alloys","bob-crystallo-circuit","vanilla-crystallo-circuit","angels-comp-circuit","angels-crystallo-circuit","angels-comp-plate"}
+
+if mods["angelsindustries"] and angelsmods.industries.components then
+	-- DEFINE BLOCKS
+	require("prototypes.omniblocks")
+	component["construction-block"] = {"block-construction-1", "block-construction-2", "block-construction-3", "block-construction-4","block-construction-5"}
+	component["electric-block"] = {"block-electronics-1", "block-electronics-2", "block-electronics-3", "block-electronics-4", "block-electronics-5"}
+	component["fluid-block"] = {"construction-frame-1", "block-fluidbox-1", nil, "block-fluidbox-2", nil}
+	component["mechanical-block"] = {"construction-frame-1", "block-mechanical-1", nil, "block-mechanical-2", nil}
+	component["enhancement-block"] = {"block-enhancement-1", "block-enhancement-2", "block-enhancement-3", "block-enhancement-4", "block-enhancement-5"}
+	component["energy-block"] = {"block-energy-1", "block-energy-2", "block-energy-3", "block-energy-4", "block-energy-5"}
+	component["logistic-block"] = {"block-logistic-1", "block-logistic-2", "block-logistic-3", "block-logistic-4", "block-logistic-5"}
+	component["production-block"] = {"block-production-1", "block-production-2", "block-production-3", "block-production-4", "block-production-5"}
+	component["omni-block"] = {"block-omni-1","block-omni-2","block-omni-3","block-omni-4","block-omni-5"}
+end
 
 for _, c in pairs(cmpn) do
 	--component[c]=setmetatable(component[c],BuildMat)

--- a/omnilib/prototypes/ingredients-generation.lua
+++ b/omnilib/prototypes/ingredients-generation.lua
@@ -33,11 +33,23 @@ component["bob-gear-box"] = {"omnicium-iron-gear-box","omnicium-steel-gear-box",
 component["angels-gear-box"] = {"omnicium-iron-gear-box","omnicium-steel-gear-box","omnicium-titanium-gear-box","omnicium-tungsten-gear-box"}
 component["bearing"]={"steel-bearing", nil, "cobalt-steel-bearing", "titanium-bearing", "nitinol-bearing", "ceramic-bearing"}
 
+if mods["angelsindustries"] and angelsmods.industries.components then
+	-- DEFINE BLOCKS
+	component["construction-block"] = {"block-construction-1", "block-construction-2", "block-construction-3", "block-construction-4","block-construction-5"}
+	component["electric-block"] = {"block-electronics-1", "block-electronics-2", "block-electronics-3", "block-electronics-4", "block-electronics-5"}
+	component["fluid-block"] = {"construction-frame-1", "block-fluidbox-1", nil, "block-fluidbox-2", nil}
+	component["mechanical-block"] = {"construction-frame-1", "block-mechanical-1", nil, "block-mechanical-2", nil}
+	component["enhancement-block"] = {"block-enhancement-1", "block-enhancement-2", "block-enhancement-3", "block-enhancement-4", "block-enhancement-5"}
+	component["energy-block"] = {"block-energy-1", "block-energy-2", "block-energy-3", "block-energy-4", "block-energy-5"}
+	component["logistic-block"] = {"block-logistic-1", "block-logistic-2", "block-logistic-3", "block-logistic-4", "block-logistic-5"}
+	component["production-block"] = {"block-production-1", "block-production-2", "block-production-3", "block-production-4", "block-production-5"}
+end
+
 --------------------------------------------------------------------------------------------------
 -- Component list swapping logic -----------------------------------------------------------------
 --------------------------------------------------------------------------------------------------
 --ELECTRONIC SWITCHES
-if mods["angelsindustries"] and angelsmods.industries.components then
+if mods["angelsindustries"] and angelsmods.industries.components then	
 	if mods["omnimatter_crystal"] then
 		component["circuit"]=component["angels-crystallo-circuit"]
 	else

--- a/omnilib/prototypes/omniblocks.lua
+++ b/omnilib/prototypes/omniblocks.lua
@@ -1,0 +1,81 @@
+
+--component["gear-box"]
+--component["omniplate"]
+--"block-omni-0" ... "block-omni-5"
+--"omnitractor-electric-1"..."omnitractor-electric-5"
+
+data:extend(
+{
+  -----------------------------------------------------------------------------
+  -- OMNI BLOCKS --------------------------------------------------------------
+  -----------------------------------------------------------------------------
+  {
+    type = "item",
+    name = "block-omni-0",
+    icons = {
+			{icon = "__angelsindustries__/graphics/icons/block-bprocessing-4.png",
+			tint = {255,0,255}},
+			{icon = "__omnilib__/graphics/lvl0.png"}
+			},
+    icon_size = 32,
+    subgroup = "omnitractor",
+    order = "a",
+    stack_size = 200,
+  },
+  {
+    type = "recipe",
+    name = "block-omni-0",
+    enabled = true,
+    category = "crafting",
+    energy_required = 5,
+    ingredients =
+    {
+      {type="item", name = "construction-frame-1", amount = 1},
+      {type="item", name = "omnicium-plate", amount = 2},
+    },
+    results=
+    {
+      {type="item", name="block-omni-0", amount=1},
+    },
+    icon_size = 32,
+  }
+})
+
+for i=1,5 do
+	plate_index = math.min(i,#component["omniplate"])
+	gbox_index = math.min(i,#component["gear-box"])
+	data:extend(
+	{
+		{
+			type = "item",
+			name = "block-omni-"..i,
+			icons = {
+				{icon = "__angelsindustries__/graphics/icons/block-bprocessing-4.png",
+				tint = {255,0,255}},
+				{icon = "__omnilib__/graphics/lvl"..i..".png"}
+				},
+			icon_size = 32,
+			subgroup = "omnitractor",
+			order = "a",
+			stack_size = 200,
+		},
+		{
+			type = "recipe",
+			name = "block-omni-"..i,
+			enabled = true,
+			category = "crafting",
+			energy_required = 5,
+			ingredients =
+			{
+			  {type="item", name = "block-omni-"..i-1, amount = 1},
+			  {type="item", name = component["omniplate"][plate_index], amount = 4},
+			  {type="item", name = component["gear-box"][gbox_index], amount = 2},
+			},
+			results=
+			{
+			  {type="item", name="block-omni-"..i, amount=1},
+			},
+			icon_size = 32,
+		}
+	})
+end

--- a/omnilib/prototypes/omniblocks.lua
+++ b/omnilib/prototypes/omniblocks.lua
@@ -1,9 +1,3 @@
-
---component["gear-box"]
---component["omniplate"]
---"block-omni-0" ... "block-omni-5"
---"omnitractor-electric-1"..."omnitractor-electric-5"
-
 data:extend(
 {
   -----------------------------------------------------------------------------
@@ -62,7 +56,7 @@ for i=1,5 do
 		{
 			type = "recipe",
 			name = "block-omni-"..i,
-			enabled = true,
+			enabled = false,
 			category = "crafting",
 			energy_required = 5,
 			ingredients =

--- a/omnimatter/data-updates.lua
+++ b/omnimatter/data-updates.lua
@@ -150,7 +150,8 @@ if mods["angelsindustries"] and angelsmods.industries.components then
 	cost:setQuant("construction-block",5):
 	setQuant("electric-block",2):
 	setQuant("fluid-block",5):
-	setQuant("logistic-block",1)
+	setQuant("logistic-block",1):
+	setQuant("omni-block",1)
 else
 	cost:setQuant("omniplate",10):
 	setQuant("plates",20):

--- a/omnimatter/data-updates.lua
+++ b/omnimatter/data-updates.lua
@@ -144,10 +144,18 @@ if true or phlog then
 local cost = OmniGen:create():
 		building():
 		setMissConstant(3):
-		setPreRequirement("burner-omniphlog"):
-		setQuant("omniplate",10):
-		setQuant("plates",20):
-		setQuant("gear-box",15)
+		setPreRequirement("burner-omniphlog")
+
+if mods["angelsindustries"] and angelsmods.industries.components then
+	cost:setQuant("construction-block",5):
+	setQuant("electric-block",2):
+	setQuant("fluid-block",5):
+	setQuant("logistic-block",1)
+else
+	cost:setQuant("omniplate",10):
+	setQuant("plates",20):
+	setQuant("gear-box",15)
+end
 
 	BuildChain:create("omnimatter","omniphlog"):
 		setSubgroup("omniphlog"):

--- a/omnimatter/data.lua
+++ b/omnimatter/data.lua
@@ -101,36 +101,47 @@ local omnic_acid = RecChain:create("omnimatter","omnic-acid"):
 		setTechTime(15):
 		extend()
 
-		BuildGen:create("omnimatter","omniphlog"):
-		setBurner(0.75,1):
-		setStacksize(10):
-		setSubgroup("omniphlog"):
-		setReplace("omniphlog"):
-		setSize(3):
-		setCrafting("omniphlog"):
-		setFluidBox("XWX.XXX.XKX"):
-		setUsage(300):
-		setAnimation({
-		layers={
-		{
-			filename = "__omnimatter__/graphics/entity/buildings/omniphlog.png",
-			priority = "extra-high",
-			width = 160,
-			height = 160,
-			frame_count = 36,
-			line_length = 6,
-			shift = {0.00, -0.05},
-			scale = 0.90,
-			animation_speed = 0.5
-		},
-		}
-		}):
-		setIngredients({
+local phlog_cost = {}
+if mods["angelsindustries"] and angelsmods.industries.components then
+	phlog_cost = {
+	{name="block-construction-1", amount=3},
+	{name="block-electronics-0", amount=1},
+	{name="block-fluidbox-1", amount=2}}
+else
+	phlog_cost = {
 		  {type = "item", name = "omnicium-plate", amount = 10},
 		  {type = "item", name = "omnicium-gear-wheel", amount = 15},
 		  {type = "item", name = "iron-plate", amount = 10},
 		  {type = "item", name = "copper-plate", amount = 5},
-		}):setEnabled():extend()
+		}
+end
+
+BuildGen:create("omnimatter","omniphlog"):
+setBurner(0.75,1):
+setStacksize(10):
+setSubgroup("omniphlog"):
+setReplace("omniphlog"):
+setSize(3):
+setCrafting("omniphlog"):
+setFluidBox("XWX.XXX.XKX"):
+setUsage(300):
+setAnimation({
+layers={
+{
+	filename = "__omnimatter__/graphics/entity/buildings/omniphlog.png",
+	priority = "extra-high",
+	width = 160,
+	height = 160,
+	frame_count = 36,
+	line_length = 6,
+	shift = {0.00, -0.05},
+	scale = 0.90,
+	animation_speed = 0.5
+},
+}
+}):
+setIngredients(phlog_cost):
+setEnabled():extend()
 
 RecGen:create("omnimatter","omnite-brick"):
 	setIngredients("stone","omnite"):

--- a/omnimatter/prototypes/omnitractor-dynamic.lua
+++ b/omnimatter/prototypes/omnitractor-dynamic.lua
@@ -3,7 +3,8 @@ if mods["angelsindustries"] and angelsmods.industries.components then
 	burner_ingredients = {
 	{name="block-construction-1", amount=3},
 	{name="block-electronics-0", amount=1},
-	{name="block-fluidbox-1", amount=1}}
+	{name="block-fluidbox-1", amount=1},
+	{name="block-omni-0", amount=1}}
 else
 	burner_ingredients = {
 	{name="omnicium-gear-wheel", amount=2},
@@ -122,8 +123,9 @@ local cost = OmniGen:create():
 if mods["angelsindustries"] and angelsmods.industries.components then
 	cost:setQuant("construction-block",5):
 	setQuant("electric-block",2):
-	setQuant("fluid-block",5)
-	--setQuant("production-block",1)
+	setQuant("fluid-block",5):
+	setQuant("production-block",1):
+	setQuant("omni-block",1)
 else
 	cost:setQuant("circuit",5):
 	setQuant("omniplate",20):

--- a/omnimatter/prototypes/omnitractor-dynamic.lua
+++ b/omnimatter/prototypes/omnitractor-dynamic.lua
@@ -1,9 +1,19 @@
-BuildGen:create("omnimatter","omnitractor"):
-	setSubgroup("omnitractor"):
-	setIngredients({
+local burner_ingredients = {}
+if mods["angelsindustries"] and angelsmods.industries.components then
+	burner_ingredients = {
+	{name="block-construction-1", amount=3},
+	{name="block-electronics-0", amount=1},
+	{name="block-fluidbox-1", amount=1}}
+else
+	burner_ingredients = {
 	{name="omnicium-gear-wheel", amount=2},
 	{name="omnicium-plate", amount=4},
-	{name="iron-plate", amount=3}}):
+	{name="iron-plate", amount=3}}
+end
+
+BuildGen:create("omnimatter","omnitractor"):
+	setSubgroup("omnitractor"):
+	setIngredients(burner_ingredients):
 	setEnergy(10):
 	setBurner(1,1):
 	setUsage(100):
@@ -56,7 +66,7 @@ local get_pure_req = function(levels,i)
 		if data.raw.technology["omnitech-omnisolvent-omnisludge-"..(i-2)] then
 			r[#r+1]="omnitech-omnisolvent-omnisludge-"..(i-2)*omni.fluid_levels_per_tier+omni.fluid_dependency
 		else
-			log("no sludge here")
+			log("this should change")
 		end
 	end
 	for j,tier in pairs(omnifluid) do
@@ -108,14 +118,19 @@ end
 local cost = OmniGen:create():
 	building():
 	setMissConstant(2):
-	setPreRequirement("burner-omnitractor"):
-	setQuant("circuit",5):
+	setPreRequirement("burner-omnitractor")
+if mods["angelsindustries"] and angelsmods.industries.components then
+	cost:setQuant("construction-block",5):
+	setQuant("electric-block",2):
+	setQuant("fluid-block",5)
+	--setQuant("production-block",1)
+else
+	cost:setQuant("circuit",5):
 	setQuant("omniplate",20):
 	setQuant("gear-box",10)
-
-
-if mods["bobplates"] then
-	cost:setQuant("bearing",5,-1)
+	if mods["bobplates"] then
+		cost:setQuant("bearing",5,-1)
+	end
 end
 
 

--- a/omnimatter/prototypes/omnitractor-dynamic.lua
+++ b/omnimatter/prototypes/omnitractor-dynamic.lua
@@ -66,8 +66,6 @@ local get_pure_req = function(levels,i)
 	if i == 2 then
 		if data.raw.technology["omnitech-omnisolvent-omnisludge-"..(i-2)] then
 			r[#r+1]="omnitech-omnisolvent-omnisludge-"..(i-2)*omni.fluid_levels_per_tier+omni.fluid_dependency
-		else
-			log("this should change")
 		end
 	end
 	for j,tier in pairs(omnifluid) do
@@ -179,3 +177,8 @@ BuildChain:create("omnimatter","omnitractor"):
 	},
 	}):setOverlay("tractor-over"):
 	extend()
+
+for i=1,settings.startup["omnimatter-max-tier"].value do
+	log("Looking for omnitractor-electric-"..i)
+	omni.lib.add_unlock_recipe("omnitractor-electric-"..i, "block-omni-"..i)
+end

--- a/omnimatter_crystal/prototypes/crystallonics.lua
+++ b/omnimatter_crystal/prototypes/crystallonics.lua
@@ -21,20 +21,38 @@ RecGen:create("omnimatter_crystal","hydromnic-acid"):
 local dif = 1
 if not mods["bobelectronics"] then dif=0 end
 
-local cost = OmniGen:create():
+local cost_plant = OmniGen:create():
 	building():
-	setMissConstant(3):
-	setQuant("pipe",15,2):
+	setMissConstant(3)
+local cost_omnizer = OmniGen:create():
+	building():
+	setMissConstant(3)
+if mods["angelsindustries"] and angelsmods.industries.components then
+	cost_plant:setQuant("construction-block",5):
+	setQuant("electric-block",2):
+	setQuant("fluid-block",5):
+	setQuant("energy-block",1)
+	cost_omnizer:setQuant("construction-block",5):
+	setQuant("electric-block",2):
+	setQuant("fluid-block",5):
+	setQuant("enhancement-block",1)
+else
+	cost_plant:setQuant("pipe",15,2):
 	setQuant("omniplate",10):
 	setQuant("gear-wheel",10):
 	setQuant("circuit",5,dif)
+	cost_omnizer:setQuant("pipe",15,2):
+	setQuant("omniplate",10):
+	setQuant("gear-wheel",10):
+	setQuant("circuit",5,dif)
+end
 
 --Omniplant
 BuildChain:create("omnimatter_crystal","omniplant"):
 	setSubgroup("omniplant"):
 	setLocName("omniplant"):
 	setIcons("omniplant","omnimatter_crystal"):
-	setIngredients(cost:ingredients()):
+	setIngredients(cost_plant:ingredients()):
 	setEnergy(25):
 	setUsage(function(level,grade) return (200+50*grade).."kW" end):
 	setTechPrereq(get_pure_req):
@@ -85,11 +103,21 @@ BuildChain:create("omnimatter_crystal","omniplant"):
 	if mods["boblogistics"] then pipe="copper-pipe" end
 	if mods["bobelectronics"] then electronic="basic-circuit-board" end
 
+    local burner_ings = {}
+	if mods["angelsindustries"] and angelsmods.industries.components then
+		burner_ings = {
+		{name="block-construction-1", amount=5},
+		{name="block-electronics-0", amount=3},
+		{name="block-fluidbox-1", amount=5}
+		}
+	else
+		burner_ings = {{pipe,15},{"omnicium-plate",5},{electronic,5},{"omnite-brick",10},{"iron-gear-wheel",10}}
+	end
 	BuildGen:create("omnimatter_crystal","omniplant"):
 	setSubgroup("omniplant"):
 	setLocName("omniplant-burner"):
 	setIcons("omniplant","omnimatter_crystal"):
-	setIngredients({pipe,15},{"omnicium-plate",5},{electronic,5},{"omnite-brick",10},{"iron-gear-wheel",10}):
+	setIngredients(burner_ings):
 	setBurner(0.75,2):
 	setEnergy(25):
 	setUsage(function(level,grade) return "750kW" end):
@@ -127,7 +155,7 @@ BuildChain:create("omnimatter_crystal","crystallomnizer"):
 	setSubgroup("crystallomnizer"):
 	setIcons("crystallomnizer","omnimatter_crystal"):
 	setLocName("crystallomnizer"):
-	setIngredients(cost:ingredients()):
+	setIngredients(cost_omnizer:ingredients()):
 	setEnergy(25):
 	setUsage(function(level,grade) return (200+50*grade).."kW" end):
 	setTechPrereq(get_pure_req):


### PR DESCRIPTION
Added initial support for omniblocks: Tier0-6 blocks that work when Angel's Industry's components are turned on. Components are created dynamically. Should support up to 5 tiers of omni, but not (yet) more than 5.

Should make Component play much more omni. 

What isn't done yet is balance. It's probably all over the place. I haven't yet tested if you can play a full game with these, but that's the same issue with components even before this PR.