### PR TITLE
Dev fixes

### DIFF
--- a/omnilib/changelog.txt
+++ b/omnilib/changelog.txt
@@ -1,6 +1,8 @@
 ---------------------------------------------------------------------------------------------------
 Version: 4.0.1
 Date: 2020.XX.XX
+  Features:
+    - Add omni.lib.iunion as a faster alternative to lib.union for merging two contiguous arrays
   Bugfixes:
     - Fixed cases where gcd function hung on NaN
     - Fixed cases where recgen wouldn't handle tech icons correctly

--- a/omnilib/control.lua
+++ b/omnilib/control.lua
@@ -41,7 +41,7 @@ local function update_last_tier(recipe, full_refresh)
 		return
 	end
 	-- We're the top of the tree!
-	if recipe_tree and metadata.variant == "" and recipe_tree.active_tier < metadata.tier then
+	if recipe_tree and metadata.variant == "" and recipe_tree.active_tier <= metadata.tier then
 		local I = full_refresh and 97 or recipe_tree.active_tier
 		local research_status = not not (recipe.force.technologies["compression-recipes"] or {}).researched
 		repeat

--- a/omnilib/prototypes/functions/functions-misc.lua
+++ b/omnilib/prototypes/functions/functions-misc.lua
@@ -219,6 +219,16 @@ function omni.lib.union(...)
 	end
 	return table.deepcopy(t)
 end
+
+-- Two arrays
+function omni.lib.iunion(dest, source)
+	local base = #dest
+	for I=1, #source do
+		dest[base+I] = source[I]
+	end
+	return dest
+end
+
 function omni.lib.dif(tab1,tab2)
 	local t = {}
 	for name,i in pairs(tab1) do

--- a/omnimatter/prototypes/recipes/extraction-dynamic.lua
+++ b/omnimatter/prototypes/recipes/extraction-dynamic.lua
@@ -6,30 +6,6 @@ function extraction_value(levels,grade)
 	return (8*levels+5*grade-13)*(3*levels+grade-4)/(4*math.pow(levels-1,2))
 end
 
-local get_item_icons = function(item,tier)
-    --Build the icons table
-    local icons = {}
-    if item.icons then
-        for _ , icon in pairs(item.icons) do
-            icons[#icons+1] = icon
-        end
-    else
-        icons[#icons+1] = {icon = item.icon}
-    end
-    return icons
-end
-local get_tech_icons = function(item)
-    --Build the icons table
-    local icon = ""
-    if not item.mod then
-		icon = "__omnimatter__"
-	else
-		icon = "__"..item.mod.."__"
-	end
-	icon=icon.."/graphics/extraction/"..item.ore.name..".png"
-    return icon
-end
-
 local reqpure = function(tier,level,item)
 	local req = {}
 	if level%omni.pure_levels_per_tier==1 or omni.pure_levels_per_tier==1 then
@@ -235,7 +211,7 @@ end
 --omni.pure_dependency > omni.pure_levels_per_tier
 --omni.max_tier
 local function generate_impure_icon(ore)
-	local ore_icon = omni.icon.of(ore.name, "item")
+	local ore_icon = table.deepcopy(omni.icon.of(ore.name, "item"))
 	for _, layer in pairs(ore_icon) do
 		layer.shift = {
 			5 * (64 / layer.icon_size),
@@ -252,7 +228,7 @@ local function generate_impure_icon(ore)
 end
 
 local function generate_pure_icon(ore)
-	local ore_icon = omni.icon.of(ore.name, "item")
+	local ore_icon = table.deepcopy(omni.icon.of(ore.name, "item"))
 	for _, layer in pairs(ore_icon) do
 		layer.shift = {
 			0,

--- a/omnimatter_compression/changelog.txt
+++ b/omnimatter_compression/changelog.txt
@@ -4,6 +4,7 @@ Date: 2020.XX.XX
   Bugfixes:
     - Fixed cases where tech compression math wasn't accurate
     - Fixed overflow on certain attributes causing crashes
+    - Fixed crash with 0 count recipes and numbers with string type
 ---------------------------------------------------------------------------------------------------
 Version: 4.0.0
 Date: 2020.08.14

--- a/omnimatter_compression/prototypes/compress-recipes.lua
+++ b/omnimatter_compression/prototypes/compress-recipes.lua
@@ -119,8 +119,9 @@ local seperate_fluid_solid = function(collection)
 	local fluid = {}
 	local solid = {}
 	if type(collection) == "table" then
-    for _,thing in pairs(collection) do
-      if thing.amount > 0 then
+    for _, thing in pairs(collection) do
+      local amount = type(thing) == "table" and tonumber(thing.amount or thing[2])
+      if not amount or (amount and amount > 0) then
         if thing.type and thing.type == "fluid" then
           fluid[#fluid+1]=thing
         else
@@ -136,7 +137,7 @@ local seperate_fluid_solid = function(collection)
           end
         end
       else
-        log("Invalid recipe with a 0 requirement/result for " .. (thing[1] or thing.name))
+        log("Invalid recipe with a 0 requirement/result!\n" .. serpent.block(collection))
       end
 		end
 	else solid[#solid+1] = {type="item",name=collection,amount=1}

--- a/omnimatter_crystal/changelog.txt
+++ b/omnimatter_crystal/changelog.txt
@@ -5,6 +5,7 @@ Date: 2020.08.xx
     - Updated to Factorio version 1.0
   Bugfixes:
     - Fixed crystallonics tech not always requiring its previous tier
+    - Fixed cases of incorrect icon generation
 ---------------------------------------------------------------------------------------------------
 Version: 3.18.8
 Date: 2020.08.13

--- a/omnimatter_crystal/data-updates.lua
+++ b/omnimatter_crystal/data-updates.lua
@@ -20,16 +20,19 @@ if mods["omnimatter_marathon"] then
 end
 
 local salt_omnide_icon = function(metal)
-	local nr = 5
 	--Build the icons table
-	local icons = {}
-	icons[#icons+1] = {icon = "__omnimatter_crystal__/graphics/icons/omnide-salt.png",icon_size=32}
-	icons[#icons+1] = {
-		icon = data.raw.item[metal].icon or data.raw.item[metal].icons[1].icon,
-		icon_size=omni.crystal.get_ore_ic_size(metal),
-		scale=0.4*32/omni.crystal.get_ore_ic_size(metal),
-		shift={-10,10}
-	}
+	local icons = util.combine_icons(
+		{{
+			icon = "__omnimatter_crystal__/graphics/icons/omnide-salt.png",
+			icon_size = 32
+		}},
+		omni.icon.of(data.raw.item[metal]),
+		{}
+	)
+	for I=2, #icons do
+		icons[I].scale = 0.4 * 32 / icons[I].icon_size
+		icons[I].shift = {-10, 10}
+	end
 	return icons
 end
 
@@ -72,10 +75,10 @@ if not mods["angelsrefining"] then
 				metal = string.sub(ore,1,string.len(ore)-string.len("-ore"))
 			end
 			if data.raw.item[plate] then
-				rec.normal.results[1].name=plate
+				rec.normal.results[1].name = plate
 				rec.icon=nil
 				rec.icon_size=nil
-				rec.icons = {{icon =data.raw.item[plate].icon, icon_size = data.raw.item[plate].icon_size}}
+				rec.icons = omni.icon.of(data.raw.item[plate])
 				rec.localised_name = {"recipe-name.item", {"item-name."..plate}}
 				local tier = 1
 				for i,t in pairs(omnisource) do
@@ -101,7 +104,6 @@ if not mods["angelsrefining"] then
 						{type="fluid",name="hydromnic-acid",amount=120},
 					},
 					icons = ic,
-					icon_size = omni.crystal.get_ore_ic_size(ore),--32,
 					results = {
 						{type="item",name=ore.."-omnide-salt",amount=1},
 					},

--- a/omnimatter_crystal/prototypes/circuit.lua
+++ b/omnimatter_crystal/prototypes/circuit.lua
@@ -296,19 +296,14 @@ function omni.crystal.generate_hybrid_circuit(control_crystal,electronic_circuit
 	--log("generating hybrid: "..cc)
 	
 	local items = {}
-	
-	local icons={}
-	local crystal_icon = data.raw.item[cc].icons
-	icons[#icons+1]={icon="__omnimatter_crystal__/graphics/blank.png"}
-	for _,ic in pairs(crystal_icon) do
-		icons[#icons+1]=ic
-		--icons[#icons].scale=0.5
-	--icons[#icons].shift={0,-5}
-	end
-	icons[#icons+1]={icon=data.raw.item[electronic_circuit].icon}
-	icons[#icons].scale=0.5
-	icons[#icons].shift={-6,8}
-	--icons[#icons+1]=
+	--	icons[#icons+1]={icon="__omnimatter_crystal__/graphics/blank.png"}
+	local icons = util.combine_icons(
+		omni.icon.of(data.raw.item[cc]),
+		omni.icon.of(data.raw.item[electronic_circuit]),
+		{}
+	)
+	icons[#icons].scale = 0.5
+	icons[#icons].shift = {-6, 8}
 	local loc = {"item-name.control_crystal_hybrid"}
 	for i = 2, #data.raw.item[cc].localised_name do
 		loc[#loc+1]=data.raw.item[cc].localised_name[i]
@@ -320,7 +315,6 @@ function omni.crystal.generate_hybrid_circuit(control_crystal,electronic_circuit
 		name = cc.."-"..electronic_circuit.."-hybrid",
         localised_name = loc,
 		icons = icons,
-		icon_size = 32,
 		flags = {"goes-to-main-inventory"},
 		subgroup = "omni-basic",
 		stack_size = 200
@@ -333,7 +327,6 @@ function omni.crystal.generate_hybrid_circuit(control_crystal,electronic_circuit
 		ingredients = {{type="item",name=cc,amount=1},{type="item",name=electronic_circuit,amount=1}},
 		order = "a[angelsore1-crushed]",
 		icons = icons,
-		icon_size = 32,
 		results = {{type = "item", name = cc.."-"..electronic_circuit.."-hybrid", amount=1}},
 		energy_required = 1,
 	}

--- a/omnimatter_crystal/prototypes/crystal-making.lua
+++ b/omnimatter_crystal/prototypes/crystal-making.lua
@@ -8,27 +8,48 @@ local shard_icons = function(metal)
     --Build the icons table
     local icons = {}
 	for i=1,nr do
-		icons[#icons+1] = {icon = "__omnimatter_crystal__/graphics/icons/"..metal.."-crystal.png",icon_size=32,scale=0.2,shift={5*math.cos(((i-1)/nr+0.5)*2*math.pi),5*math.sin(((i-1)/nr+0.5)*2*math.pi)}}
+		icons[#icons+1] = {
+			icon = "__omnimatter_crystal__/graphics/icons/"..metal.."-crystal.png",
+			icon_size=32,
+			scale=0.2,
+			shift={5*math.cos(((i-1)/nr+0.5)*2*math.pi),5*math.sin(((i-1)/nr+0.5)*2*math.pi)}
+		}
 	end
     return icons
 end
 
 local metal_omnide_icon = function(metal)
-	local nr = 5
     --Build the icons table
-    local icons = {}
-	icons[#icons+1] = {icon = "__omnimatter_crystal__/graphics/icons/omnide-solution.png",icon_size=32}
-	icons[#icons+1] = {icon = data.raw.item[metal].icon,icon_size=omni.crystal.get_ore_ic_size(metal),scale=0.4*32/omni.crystal.get_ore_ic_size(metal),shift={-10,10}}
+    local icons = util.combine_icons(
+		{{
+			icon = "__omnimatter_crystal__/graphics/icons/omnide-solution.png",
+			icon_size = 32
+		}},
+		omni.icon.of(data.raw.item[metal]),
+		{}
+	)
+	for I=2, #icons do
+		icons[I].scale = 0.4 * 32 / icons[I].icon_size
+		icons[I].shift = {-10, 10}
+	end
     return icons
 end
 
 local salt_omnide_icon = function(metal)
-	local nr = 5
-    --Build the icons table
-    local icons = {}
-	icons[#icons+1] = {icon = "__omnimatter_crystal__/graphics/icons/omnide-salt.png",icon_size=32}
-	icons[#icons+1] = {icon = data.raw.item[metal].icon,icon_size=omni.crystal.get_ore_ic_size(metal),scale=0.4*32/omni.crystal.get_ore_ic_size(metal),shift={-10,10}}
-    return icons
+	--Build the icons table
+	local icons = util.combine_icons(
+		{{
+			icon = "__omnimatter_crystal__/graphics/icons/omnide-salt.png",
+			icon_size = 32
+		}},
+		omni.icon.of(data.raw.item[metal]),
+		{}
+	)
+	for I=2, #icons do
+		icons[I].scale = 0.4 * 32 / icons[I].icon_size
+		icons[I].shift = {-10, 10}
+	end
+	return icons
 end
 
 

--- a/omnimatter_crystal/prototypes/functions.lua
+++ b/omnimatter_crystal/prototypes/functions.lua
@@ -4,13 +4,3 @@ function Set (list)
     for _, l in ipairs(list) do set[l.name] = l end
     return set
 end
-
-omni.crystal.get_ore_ic_size=function(metal_ore)
-	local ic_sz=32
-	if data.raw.item[metal_ore].icon_size then
-		ic_sz=data.raw.item[metal_ore].icon_size
-	elseif data.raw.item[metal_ore].icons and data.raw.item[metal_ore].icons[1].icon_size then
-		ic_sz=data.raw.item[metal_ore].icons[1].icon_size
-	end
-	return ic_sz
-end

--- a/omnimatter_crystal/prototypes/recipes/angels.lua
+++ b/omnimatter_crystal/prototypes/recipes/angels.lua
@@ -59,16 +59,19 @@ local results_nodule_solvation=function(recipe)
 end
 --icons
 local salt_omnide_icon = function(metal)
-	local nr = 5
 	--Build the icons table
-	local icons = {}
-	icons[#icons+1] = {icon = "__omnimatter_crystal__/graphics/icons/omnide-salt.png",icon_size=32}
-	icons[#icons+1] = {
-		icon = data.raw.item[metal].icon or data.raw.item[metal].icons[1].icon,
-		icon_size=omni.crystal.get_ore_ic_size(metal),
-		scale=0.4*32/omni.crystal.get_ore_ic_size(metal),
-		shift={-10,10}
-	}
+	local icons = util.combine_icons(
+		{{
+			icon = "__omnimatter_crystal__/graphics/icons/omnide-salt.png",
+			icon_size = 32
+		}},
+		omni.icon.of(data.raw.item[metal]),
+		{}
+	)
+	for I=2, #icons do
+		icons[I].scale = 0.4 * 32 / icons[I].icon_size
+		icons[I].shift = {-10, 10}
+	end
 	return icons
 end
 --checks

--- a/omnimatter_crystal/prototypes/recipes/bobs.lua
+++ b/omnimatter_crystal/prototypes/recipes/bobs.lua
@@ -16,7 +16,7 @@ if bobmods and bobmods.ores then
     }
     for i, ore in pairs(bobmods.ores) do --check ore triggers (works with plates)
         if ore.enabled and products[ore.name] then
-            omni.crystal.add_crystal(ore.name,products[ore.name])
+            omni.crystal.add_crystal(ore.name, products[ore.name])
         end
     end
 end

--- a/omnimatter_permutation/changelog.txt
+++ b/omnimatter_permutation/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: X.XX.X
+Date: 2020.XX.XX
+  Features:
+    - Significant performance increase
+  Bugfixes:
+    - Fixed cases where we would run out of RAM with large include lists on prod modules
+---------------------------------------------------------------------------------------------------
 Version: 1.18.0
 Date: 2020.04.02
   Features:

--- a/omnimatter_permutation/data-final-fixes.lua
+++ b/omnimatter_permutation/data-final-fixes.lua
@@ -108,7 +108,16 @@ for _,rec in pairs(data.raw.recipe) do
 end
 log(serpent.block(data.raw.recipe["ingot-mingnisium"]))
 --error("derp")
-if #recipesExpanded>0 then data:extend(recipesExpanded) end
+
+local rawsize = table_size(data.raw.recipe) + #recipesExpanded
+if rawsize > 65535 then
+	error("data.raw.recipe exceeds the limit of 65535 (" .. rawsize .. "). Please disable either your largest mod or omnipermute.")
+end
+
+if #recipesExpanded > 0 then
+	data:extend(recipesExpanded)
+end
+
 for _,tech in pairs(data.raw.technology) do
 	if tech.effects then
 		for i,eff in pairs(tech.effects) do
@@ -121,14 +130,17 @@ for _,tech in pairs(data.raw.technology) do
 		end
 	end
 end
+
+
+
 for _,mod in pairs(data.raw.module) do
 	if mod.limitation then
 		local newRestrict = {}
-		for i,restrict in pairs(mod.limitation) do
+		for i, restrict in pairs(mod.limitation) do
 			if techRec[restrict] then
-				newRestrict=omni.lib.union(newRestrict,techRec[restrict])
+				newRestrict = omni.lib.iunion(newRestrict, techRec[restrict])
 			else
-				newRestrict[#newRestrict+1]=restrict
+				newRestrict[#newRestrict+1] = restrict
 			end
 		end
 		mod.limitation = table.deepcopy(newRestrict)


### PR DESCRIPTION
Contains:
~1000x (yes, benchmarked) performance increase in omnipermute's module handling
Catch cases of >65535 recipes
Gracefully handle recipes with products or ingredients that have a count of 0, or where the count is a string
Fix crystal icon generation to fit with current specs, and handle cases of incorrect scaling
