### PR TITLE
use K2´s interface call to remove the kr-crash-site-generator

### DIFF
--- a/omnimatter_energy/control.lua
+++ b/omnimatter_energy/control.lua
@@ -165,9 +165,15 @@ local function Robot_Tile_Remove(event)
       return solar_mat_removed_at(robot.surface,robot.position)
       end
    end
+
+local function call_remote_functions()
+	if game.active_mods["Krastorio2"] and remote.interfaces["kr-crash-site"] then
+		remote.call("kr-crash-site","remove_crash_site_entity","kr-crash-site-generator")
+	end
+end
 --------------------------------------------------------------------
 
-
+script.on_init(call_remote_functions)
 
 local build_events = {defines.events.on_built_entity, defines.events.on_robot_built_entity}
 script.on_event(build_events, On_Built)

--- a/omnimatter_energy/prototypes/compat/krastorio2.lua
+++ b/omnimatter_energy/prototypes/compat/krastorio2.lua
@@ -98,16 +98,6 @@ if mods["Krastorio2"] then
             }}
         }
     end
-    
-    --Set crash site reactor output to 0 until K2 added the commented out interface below to remove it.
-    --remote.interfaces["kr-crash-site"].remove_crash_site_entity("kr-crash-site-generator")
-    data.raw["electric-energy-interface"]["kr-crash-site-generator"].energy_source = {
-        type = "electric",
-    	buffer_capacity = "0kJ",
-    	usage_priority = "primary-output",
-    	input_flow_limit = "0kW",
-    	output_flow_limit = "0kW"}
-    data.raw["electric-energy-interface"]["kr-crash-site-generator"].energy_production  = "0kW"
 
     --Add Basic tech card to all omni science up to t2(greens)
     --Baic tech cards are not used for mid-late game techs, thats why we cant add them as t1 pack to lib


### PR DESCRIPTION
crashes in current K2 portal release due to a typo on their side.

Fixed in their dev, merge with their next release.