### PR TITLE
(Infinite-) Omnite autoplace rewrite

### DIFF
--- a/omnimatter/changelog.txt
+++ b/omnimatter/changelog.txt
@@ -8,6 +8,10 @@ Date: 2021.01.xx
     - remove_fluid(), get_ore_tier(), set_ore_tier(), add_initial(), add_omniwater_extraction()
   Bugfixes:
     - Fixed that omnitiles used the stone path transitions
+    - Complete rewrite of omnite´s autoplace control
+    - Fixes infinite omnite spawing in the starting area
+    - Fixes map gen presets not affecting omnite generator settings
+    - Fixes infinite omnite patches not spawning in the middle of normal omnite patches
 ---------------------------------------------------------------------------------------------------
 Version: 4.1.7
 Date: 2021.01.08

--- a/omnimatter/data.lua
+++ b/omnimatter/data.lua
@@ -9,8 +9,8 @@ require("prototypes.compat.extraction-functions")
 
 --LOAD ALL OTHER PROTOTYPES
 require("prototypes.omniore")
-require("prototypes.generation.omnite-inf")
 require("prototypes.generation.omnite")
+require("prototypes.generation.omnite-inf")
 require("prototypes.compat.extraction-resources")
 
 require("prototypes.buildings.omnitractor")

--- a/omnimatter/prototypes/generation/omnite-inf.lua
+++ b/omnimatter/prototypes/generation/omnite-inf.lua
@@ -65,7 +65,7 @@ if settings.startup["omnimatter-infinite"].value then
             selection_box = {{ -0.5, -0.5}, {0.5, 0.5}},
             autoplace = 
                 resource_autoplace.resource_autoplace_settings({
-                starting_area = false,
+                has_starting_area_placement = false,
                 name ="infinite-omnite",
                 patch_set_name = "omnite",
                 order = "b",

--- a/omnimatter/prototypes/generation/omnite-inf.lua
+++ b/omnimatter/prototypes/generation/omnite-inf.lua
@@ -1,20 +1,36 @@
+local resource_autoplace = require("resource-autoplace")
+
 if settings.startup["omnimatter-infinite"].value then
     local mine={}
     if settings.startup["omnimatter-infinite-omnic-acid"].value then
         mine = {
-            hardness = 1,
+            hardness = 0.9,
             mining_particle = "omnite-particle",
-            mining_time = 1.0,
-            result = "omnite",
+            mining_time = 1,
             fluid_amount = 10,
-            required_fluid = "omnic-acid"
+            required_fluid = "omnic-acid",
+            results = {
+                {
+                  type = "item",
+                  name = "omnite",
+                  amount_min = 1,
+                  amount_max = 1
+                }
+            }
         }
     else
         mine = {
-            hardness = 1,
+            hardness = 0.9,
             mining_particle = "omnite-particle",
-            mining_time = 1.0,
-            result = "omnite"
+            mining_time = 1,
+            results = {
+              {
+                type = "item",
+                name = "omnite",
+                amount_min = 1,
+                amount_max = 1
+              }
+            }
         }
     end
 
@@ -23,61 +39,78 @@ if settings.startup["omnimatter-infinite"].value then
             type = "autoplace-control",
             name = "infinite-omnite",
             richness = true,
-            order = "b-e",
-            category = "resource",
+            order = "b",
+            category = "resource"
         },
-        {
-            type = "noise-layer",
-            name = "infinite-omnite"
-        },
+
+        --{
+        --    type = "noise-layer",
+        --    name = "infinite-omnite"
+        --},
+
         {
             type = "resource",
             name = "infinite-omnite",
             icon = "__omnimatter__/graphics/icons/omnite.png",
             icon_size = 32,
             flags = {"placeable-neutral"},
+            tree_removal_probability = 0.8,
+            tree_removal_max_distance = 32 * 32,
+            infinite_depletion_amount = 10,
+            resource_patch_search_radius = 12,
             order="a-b-a",
             --map_color = {r=0.34, g=0.00, b=0.51},
             map_color = {r=0.22, g=0.00, b=0.255},
             infinite=true,
-            minimum=375,
-            normal=1500,
-            maximum=6000,
+            glow = true,
+            minimum = 50,
+            normal = 1500,
+            maximum = 6000,
             minable = mine,
             collision_box = {{ -0.1, -0.1}, {0.1, 0.1}},
             selection_box = {{ -0.5, -0.5}, {0.5, 0.5}},
-            autoplace ={
-                control = "infinite-omnite",
-                sharpness = 1,
-                richness_multiplier = 5000,
-                richness_multiplier_distance_bonus = 20,
-                richness_base = 2000,
-                coverage = 0.01,
-                peaks = {
-                    {
-                        noise_layer = "infinite-omnite",
-                        noise_octaves_difference = -2.5,
-                        noise_persistence = 0.3,
-                        starting_area_weight_optimal = 0,
-                        starting_area_weight_range = 0,
-                        starting_area_weight_max_range = 2,
-                    },
-                    {
-                        noise_layer = "infinite-omnite",
-                        noise_octaves_difference = -2,
-                        noise_persistence = 0.3,
-                        starting_area_weight_optimal = 1,
-                        starting_area_weight_range = 0,
-                        starting_area_weight_max_range = 2,
-                    },
-                    {
-                        influence = 0.15,
-                        starting_area_weight_optimal = 0,
-                        starting_area_weight_range = 0,
-                        starting_area_weight_max_range = 2,
-                    }
-                }
-            },
+            autoplace = 
+                resource_autoplace.resource_autoplace_settings({
+                starting_area = false,
+                name ="infinite-omnite",
+                patch_set_name = "omnite",
+                order = "b",
+                base_density = 10,
+			    regular_rq_factor_multiplier = 1.10,
+            }),
+            --autoplace = {
+                --control = "infinite-omnite",
+                -- sharpness = 1,
+                -- richness_multiplier = 5000,
+                -- richness_multiplier_distance_bonus = 20,
+                -- richness_base = 2000,
+                -- coverage = 0.01,
+                -- starting_rq_factor_multiplier = 1.5
+                -- peaks = {
+                --     {
+                --         noise_layer = "infinite-omnite",
+                --         noise_octaves_difference = -2.5,
+                --         noise_persistence = 0.3,
+                --         starting_area_weight_optimal = 0,
+                --         starting_area_weight_range = 0,
+                --         starting_area_weight_max_range = 2,
+                --     },
+                --     {
+                --         noise_layer = "infinite-omnite",
+                --         noise_octaves_difference = -2,
+                --         noise_persistence = 0.3,
+                --         starting_area_weight_optimal = 1,
+                --         starting_area_weight_range = 0,
+                --         starting_area_weight_max_range = 2,
+                --     },
+                --     {
+                --         influence = 0.15,
+                --         starting_area_weight_optimal = 0,
+                --         starting_area_weight_range = 0,
+                --         starting_area_weight_max_range = 2,
+                --     }
+                -- }
+            --},
             stage_counts = {1000, 600, 400, 200, 100, 50, 20, 1},
             stages = {
                 sheet = {
@@ -123,4 +156,6 @@ if settings.startup["omnimatter-infinite"].value then
             }
         }
     })
+
+    omni.matter.apply_presets("infinite-omnite")
 end

--- a/omnimatter/prototypes/generation/omnite-inf.lua
+++ b/omnimatter/prototypes/generation/omnite-inf.lua
@@ -57,7 +57,7 @@ if settings.startup["omnimatter-infinite"].value then
             map_color = {r=0.22, g=0.00, b=0.255},
             infinite=true,
             glow = true,
-            minimum = 50,
+            minimum = 375,
             normal = 1500,
             maximum = 6000,
             minable = mine,
@@ -69,34 +69,11 @@ if settings.startup["omnimatter-infinite"].value then
                 name ="infinite-omnite",
                 patch_set_name = "omnite",
                 order = "b",
-                base_density = 30, --base density of of normal omnite is 35, if this is the same roughly every patch has infinite omnite
-			    regular_rq_factor_multiplier = 0.3,
+                base_density = 25, -- ~ richness
+                base_spots_per_km2 = 7, --base spots of of normal omnite is 10, if this is the same roughly every patch has infinite omnite
+			    regular_rq_factor_multiplier = 0.4,
                 starting_rq_factor_multiplier = 0.5,
                 richness_multiplier_distance_bonus = 20,
-                peaks = {
-                    {
-                        noise_layer = "infinite-omnite",
-                        noise_octaves_difference = -2.5,
-                        noise_persistence = 0.3,
-                        starting_area_weight_optimal = 0,
-                        starting_area_weight_range = 0,
-                        starting_area_weight_max_range = 2,
-                    },
-                    {
-                        noise_layer = "infinite-omnite",
-                        noise_octaves_difference = -2,
-                        noise_persistence = 0.3,
-                        starting_area_weight_optimal = 1,
-                        starting_area_weight_range = 0,
-                        starting_area_weight_max_range = 2,
-                    },
-                    {
-                        influence = 0.15,
-                        starting_area_weight_optimal = 0,
-                        starting_area_weight_range = 0,
-                        starting_area_weight_max_range = 2,
-                    }
-                }
             }),
             --autoplace = {
                 --control = "infinite-omnite",

--- a/omnimatter/prototypes/generation/omnite-inf.lua
+++ b/omnimatter/prototypes/generation/omnite-inf.lua
@@ -71,43 +71,10 @@ if settings.startup["omnimatter-infinite"].value then
                 order = "b",
                 base_density = 25, -- ~ richness
                 base_spots_per_km2 = 7, --base spots of of normal omnite is 10, if this is the same roughly every patch has infinite omnite
-			    regular_rq_factor_multiplier = 0.4,
+                regular_rq_factor_multiplier = 0.4,
                 starting_rq_factor_multiplier = 0.5,
                 richness_multiplier_distance_bonus = 20,
             }),
-            --autoplace = {
-                --control = "infinite-omnite",
-                -- sharpness = 1,
-                -- richness_multiplier = 5000,
-                -- richness_multiplier_distance_bonus = 20,
-                -- richness_base = 2000,
-                -- coverage = 0.01,
-                -- starting_rq_factor_multiplier = 1.5
-                -- peaks = {
-                --     {
-                --         noise_layer = "infinite-omnite",
-                --         noise_octaves_difference = -2.5,
-                --         noise_persistence = 0.3,
-                --         starting_area_weight_optimal = 0,
-                --         starting_area_weight_range = 0,
-                --         starting_area_weight_max_range = 2,
-                --     },
-                --     {
-                --         noise_layer = "infinite-omnite",
-                --         noise_octaves_difference = -2,
-                --         noise_persistence = 0.3,
-                --         starting_area_weight_optimal = 1,
-                --         starting_area_weight_range = 0,
-                --         starting_area_weight_max_range = 2,
-                --     },
-                --     {
-                --         influence = 0.15,
-                --         starting_area_weight_optimal = 0,
-                --         starting_area_weight_range = 0,
-                --         starting_area_weight_max_range = 2,
-                --     }
-                -- }
-            --},
             stage_counts = {1000, 600, 400, 200, 100, 50, 20, 1},
             stages = {
                 sheet = {

--- a/omnimatter/prototypes/generation/omnite-inf.lua
+++ b/omnimatter/prototypes/generation/omnite-inf.lua
@@ -39,15 +39,9 @@ if settings.startup["omnimatter-infinite"].value then
             type = "autoplace-control",
             name = "infinite-omnite",
             richness = true,
-            order = "b",
+            order = "b-b",
             category = "resource"
         },
-
-        --{
-        --    type = "noise-layer",
-        --    name = "infinite-omnite"
-        --},
-
         {
             type = "resource",
             name = "infinite-omnite",
@@ -58,7 +52,7 @@ if settings.startup["omnimatter-infinite"].value then
             tree_removal_max_distance = 32 * 32,
             infinite_depletion_amount = 10,
             resource_patch_search_radius = 12,
-            order="a-b-a",
+            order="b",
             --map_color = {r=0.34, g=0.00, b=0.51},
             map_color = {r=0.22, g=0.00, b=0.255},
             infinite=true,
@@ -75,8 +69,9 @@ if settings.startup["omnimatter-infinite"].value then
                 name ="infinite-omnite",
                 patch_set_name = "omnite",
                 order = "b",
-                base_density = 10,
-			    regular_rq_factor_multiplier = 1.10,
+                base_density = 5,
+			    regular_rq_factor_multiplier = 0.3,
+			    starting_rq_factor_multiplier = 0.5,
             }),
             --autoplace = {
                 --control = "infinite-omnite",

--- a/omnimatter/prototypes/generation/omnite-inf.lua
+++ b/omnimatter/prototypes/generation/omnite-inf.lua
@@ -69,9 +69,34 @@ if settings.startup["omnimatter-infinite"].value then
                 name ="infinite-omnite",
                 patch_set_name = "omnite",
                 order = "b",
-                base_density = 5,
+                base_density = 30, --base density of of normal omnite is 35, if this is the same roughly every patch has infinite omnite
 			    regular_rq_factor_multiplier = 0.3,
-			    starting_rq_factor_multiplier = 0.5,
+                starting_rq_factor_multiplier = 0.5,
+                richness_multiplier_distance_bonus = 20,
+                peaks = {
+                    {
+                        noise_layer = "infinite-omnite",
+                        noise_octaves_difference = -2.5,
+                        noise_persistence = 0.3,
+                        starting_area_weight_optimal = 0,
+                        starting_area_weight_range = 0,
+                        starting_area_weight_max_range = 2,
+                    },
+                    {
+                        noise_layer = "infinite-omnite",
+                        noise_octaves_difference = -2,
+                        noise_persistence = 0.3,
+                        starting_area_weight_optimal = 1,
+                        starting_area_weight_range = 0,
+                        starting_area_weight_max_range = 2,
+                    },
+                    {
+                        influence = 0.15,
+                        starting_area_weight_optimal = 0,
+                        starting_area_weight_range = 0,
+                        starting_area_weight_max_range = 2,
+                    }
+                }
             }),
             --autoplace = {
                 --control = "infinite-omnite",

--- a/omnimatter/prototypes/generation/omnite.lua
+++ b/omnimatter/prototypes/generation/omnite.lua
@@ -1,3 +1,5 @@
+local resource_autoplace = require("resource-autoplace")
+
 ItemGen:create("omnimatter","omnite"):
 	setFuelValue(2):
 	setStacksize(500):
@@ -140,54 +142,71 @@ data:extend(
 }
 )
 data:extend{
-  	{
-	type = "autoplace-control",
-	name = "omnite",
-	richness = true,
+  {
+    type = "autoplace-control",
+    name = "omnite",
+    richness = true,
     category = "resource",
-	order = "b-e"
-	},
-	{
-	type = "noise-layer",
-	name = "omnite"
-	},
+    order = "a"
+  },
   {
     type = "resource",
     name = "omnite",
     icon = "__omnimatter__/graphics/icons/omnite.png",
     icon_size = 32,
     flags = {"placeable-neutral"},
-    order="a-b-e",
-    minable =
-    {
+    tree_removal_probability = 0.8,
+    tree_removal_max_distance = 32 * 32,
+    infinite_depletion_amount = 10,
+    resource_patch_search_radius = 12,
+    order="b-da",
+    infinite = false,
+    minable = {
       hardness = 0.9,
-      mining_particle = "stone-particle",
+      mining_particle = "omnite-particle",
       mining_time = 1,
-      result = "omnite",
-      --fluid_amount = 10,
-      --required_fluid = "sulfuric-acid"
+      results = {
+        {
+          type = "item",
+          name = "omnite",
+          amount_min = 1,
+          amount_max = 1
+        }
+      }
     },
     collision_box = {{ -0.1, -0.1}, {0.1, 0.1}},
     selection_box = {{ -0.5, -0.5}, {0.5, 0.5}},
     autoplace =
-    {
-      control = "omnite",
-      sharpness = 1,
-      richness_multiplier = 2000,
-      richness_multiplier_distance_bonus = 15,
-      richness_base = 1000,
-      coverage = 0.03,
-      peaks =
-      {
-        {
-          noise_layer = "omnite",
-          noise_octaves_difference = -1.5,
-          noise_persistence = 0.3,
-        },
-      },
-      starting_area_size = 600 * 0.01,
-      starting_area_amount = 1000
-    },
+      resource_autoplace.resource_autoplace_settings({
+        name = "omnite",
+        order = "a",
+        base_density = 10, --8
+        has_starting_area_placement = true,
+        regular_rq_factor_multiplier = 1.5,
+        starting_rq_factor_multiplier = 3,
+        candidate_spot_count = 22,
+      }),
+
+    -- {
+    --   control = "omnite",
+    --   sharpness = 1,
+    --   richness_multiplier = 2000,
+    --   richness_multiplier_distance_bonus = 15,
+    --   richness_base = 1000,
+    --   coverage = 0.03,
+    --   peaks =
+    --   {
+    --     {
+    --       noise_layer = "omnite",
+    --       noise_octaves_difference = -1.5,
+    --       noise_persistence = 0.3,
+    --     },
+    --   },
+    --   starting_area_size = 600 * 0.01,
+    --   starting_area_amount = 1000
+    -- },
+
+
     stage_counts = {1000, 600, 400, 200, 100, 50, 20, 1},
     stages =
     {
@@ -244,3 +263,21 @@ data:extend{
   }
 
 }
+
+--Apply preset configs to omnite and infinite omnite if it exists
+function omni.matter.apply_presets(resource)
+  local presets = {
+    ["rich-resources"] = {richness = "very-good"},
+    ["rail-world"] = {frequency = 0.33333333333, size = 3},
+    ["ribbon-world"] = {frequency = 3, size = 0.5, richness = 2}
+  }
+
+  for preset, conf in pairs(presets) do
+    local set = data.raw["map-gen-presets"]["default"][preset]
+    if set and set.basic_settings and set.basic_settings.autoplace_controls then
+        set.basic_settings.autoplace_controls[resource] = conf
+    end
+  end
+end
+
+omni.matter.apply_presets("omnite")

--- a/omnimatter/prototypes/generation/omnite.lua
+++ b/omnimatter/prototypes/generation/omnite.lua
@@ -147,7 +147,7 @@ data:extend{
     name = "omnite",
     richness = true,
     category = "resource",
-    order = "a"
+    order = "b-a"
   },
   {
     type = "resource",
@@ -179,12 +179,12 @@ data:extend{
     autoplace =
       resource_autoplace.resource_autoplace_settings({
         name = "omnite",
-        order = "a",
-        base_density = 10, --8
+        order = "b-da",
         has_starting_area_placement = true,
-        regular_rq_factor_multiplier = 1.5,
-        starting_rq_factor_multiplier = 3,
-        candidate_spot_count = 22,
+        base_density = 10,
+        regular_rq_factor_multiplier = 1.0,
+        starting_rq_factor_multiplier = 1.5,
+        --candidate_spot_count = 22
       }),
 
     -- {

--- a/omnimatter/prototypes/generation/omnite.lua
+++ b/omnimatter/prototypes/generation/omnite.lua
@@ -190,8 +190,7 @@ data:extend{
         starting_rq_factor_multiplier = 2.4,
         richness_multiplier_distance_bonus = 20,
         base_spots_per_km2 = 10, -- ~frequency
-        peaks =
-        {
+        peaks = {
           {
             noise_layer = "omnite",
             noise_octaves_difference = -1.5,
@@ -199,32 +198,9 @@ data:extend{
           },
         },
       }),
-
-    -- {
-    --   control = "omnite",
-    --   sharpness = 1,
-    --   richness_multiplier = 2000,
-    --   richness_multiplier_distance_bonus = 15,
-    --   richness_base = 1000,
-    --   coverage = 0.03,
-    --   peaks =
-    --   {
-    --     {
-    --       noise_layer = "omnite",
-    --       noise_octaves_difference = -1.5,
-    --       noise_persistence = 0.3,
-    --     },
-    --   },
-    --   starting_area_size = 600 * 0.01,
-    --   starting_area_amount = 1000
-    -- },
-
-
     stage_counts = {1000, 600, 400, 200, 100, 50, 20, 1},
-    stages =
-    {
-      sheet =
-      {
+    stages = {
+      sheet = {
         filename = "__omnimatter__/graphics/entity/ores/omnite.png",
         priority = "extra-high",
         width = 64,
@@ -242,10 +218,8 @@ data:extend{
         }
       }
     },
-    stages_effect =
-    {
-      sheet =
-      {
+    stages_effect = {
+      sheet = {
         filename = "__omnimatter__/graphics/entity/ores/omnite-glow.png",
         priority = "extra-high",
         width = 64,
@@ -274,7 +248,6 @@ data:extend{
     max_effect_alpha = 0.3,
     map_color = {r=0.34, g=0.00, b=0.51},
   }
-
 }
 
 --Apply preset configs to omnite and infinite omnite if it exists

--- a/omnimatter/prototypes/generation/omnite.lua
+++ b/omnimatter/prototypes/generation/omnite.lua
@@ -188,11 +188,7 @@ data:extend{
         base_density = 35,    -- ~richness
         regular_rq_factor_multiplier = 1.8, --Size
         starting_rq_factor_multiplier = 2.4,
-        --sharpness = 1,
-        --richness_base = 5000,
-        --richness_multiplier = 30000,
         richness_multiplier_distance_bonus = 20,
-        -- coverage = 0.03,
         base_spots_per_km2 = 10, -- ~frequency
         peaks =
         {
@@ -202,8 +198,6 @@ data:extend{
             noise_persistence = 0.3,
           },
         },
-        --starting_area_size = 600 * 0.01,
-        --starting_area_amount = 1000
       }),
 
     -- {

--- a/omnimatter/prototypes/generation/omnite.lua
+++ b/omnimatter/prototypes/generation/omnite.lua
@@ -150,6 +150,10 @@ data:extend{
     order = "b-a"
   },
   {
+    type = "noise-layer",
+    name = "omnite"
+  },
+  {
     type = "resource",
     name = "omnite",
     icon = "__omnimatter__/graphics/icons/omnite.png",
@@ -158,7 +162,7 @@ data:extend{
     tree_removal_probability = 0.8,
     tree_removal_max_distance = 32 * 32,
     infinite_depletion_amount = 10,
-    resource_patch_search_radius = 12,
+    resource_patch_search_radius = 10,
     order="b-da",
     infinite = false,
     minable = {
@@ -181,10 +185,25 @@ data:extend{
         name = "omnite",
         order = "b-da",
         has_starting_area_placement = true,
-        base_density = 10,
-        regular_rq_factor_multiplier = 1.0,
-        starting_rq_factor_multiplier = 1.5,
-        --candidate_spot_count = 22
+        base_density = 35,    -- ~richness
+        regular_rq_factor_multiplier = 1.8, --Size
+        starting_rq_factor_multiplier = 2.4,
+        --sharpness = 1,
+        --richness_base = 5000,
+        --richness_multiplier = 30000,
+        richness_multiplier_distance_bonus = 20,
+        -- coverage = 0.03,
+        base_spots_per_km2 = 10, -- ~frequency
+        peaks =
+        {
+          {
+            noise_layer = "omnite",
+            noise_octaves_difference = -1.5,
+            noise_persistence = 0.3,
+          },
+        },
+        --starting_area_size = 600 * 0.01,
+        --starting_area_amount = 1000
       }),
 
     -- {


### PR DESCRIPTION
Rewrite autoplace controls to use vanillas functions.
Fixes #129 and 
Fixes #301

Known issues:

- [x] Frequency needs to be increased
- [x] Infinite omnite spawns on the edges of patches instead of in the center