### PR TITLE
Compression fixes

### DIFF
--- a/omnimatter_compression/changelog.txt
+++ b/omnimatter_compression/changelog.txt
@@ -1,3 +1,11 @@
+Version: 4.1.8
+Date: 2021.07.24
+  Changes:
+    - Burner assemblers have less of a speed penalty compared to their electric brethren (they are still less efficient in ore/watt, and cannot take modules)
+    - Add an entry to game log when not compressing items due to massive stack sizes
+  Bugfixes:
+    - Fix some buildings losing their crafting categories when compressed
+    - Fix handling outputs > 65535
 ---------------------------------------------------------------------------------------------------
 Version: 4.1.7
 Date: 2021.06.02

--- a/omnimatter_compression/info.json
+++ b/omnimatter_compression/info.json
@@ -1,6 +1,6 @@
 {
 "name":"omnimatter_compression",
-"version": "4.1.7",
+"version": "4.1.8",
 "title":"Omnicompression",
 "author":"EmperorZelos",
 "contact": "https://discord.gg/WQYks7W",

--- a/omnimatter_compression/prototypes/compress-buildings.lua
+++ b/omnimatter_compression/prototypes/compress-buildings.lua
@@ -405,7 +405,7 @@ local run_entity_updates = function(new, kind, i)
   end
   --recipe category settings for assembly/furnace types
   if kind == "assembling-machine" or kind == "furnace" or kind == "rocket-silo" then
-    local new_cat = {} --clear each time
+    local new_cat = table.deepcopy(new.crafting_categories) --revert each time
     for j, cat in pairs(new.crafting_categories) do
       if not data.raw["recipe-category"][cat.."-compressed"] then --check if category exists
         if not omni.lib.is_in_table(cat.."-compressed", recipe_category) then --check not already in the to-expand table

--- a/omnimatter_compression/prototypes/compress-buildings.lua
+++ b/omnimatter_compression/prototypes/compress-buildings.lua
@@ -500,7 +500,11 @@ local run_entity_updates = function(new, kind, i)
   end
   --mining speed and radius update
   if kind == "mining-drill" then
-    new.mining_speed = new.mining_speed * math.pow(multiplier,i/2)
+    local speed_divisor = 2
+    if new.energy_source and new.energy_source.type ~= "electric" then
+      speed_divisor = 1
+    end
+    new.mining_speed = new.mining_speed * math.pow(multiplier,i/speed_divisor)
     --new.mining_power = new.mining_power * math.pow(multiplier,i/2)
     new.resource_searching_radius = new.resource_searching_radius *(i+1)
   end

--- a/omnimatter_compression/prototypes/compress-items.lua
+++ b/omnimatter_compression/prototypes/compress-items.lua
@@ -349,6 +349,9 @@ for group in pairs(data.raw) do
       then
         generate_compressed_item(item)
       elseif not compressed_item_names["compressed-"..item.name] then--exclude item
+        if item.stack_size > max_stack_size_to_compress then
+          log("Excluding >max stack size: " .. item.name .. "(" .. item.stack_size .. ")")
+        end
         excluded_items[item.name] = true
       end      
     end

--- a/omnimatter_compression/prototypes/compress-recipes.lua
+++ b/omnimatter_compression/prototypes/compress-recipes.lua
@@ -317,7 +317,8 @@ function adjustOutput(recipe)
 					end
 				end
       end
-      for _, res in pairs(recipe[dif].results) do
+      for resIndex=1, #recipe[dif].results do
+        local res = recipe[dif].results[resIndex]
         if div then
           res.amount = res.amount / div
         end
@@ -349,9 +350,14 @@ function adjustOutput(recipe)
               res.amount = (launch_item.stack_size == 1) and 1 or res.amount -- Revert amount if necessary
             end
           end
-          if res.amount > 10^16 then
-            res.amount = math.ceil(res.amount / 2)
-            table.insert(recipe[dif].results, table.deepcopy(res))
+          if res.amount >= 2^16 then
+            -- Split output into res/65535 + remainder different results to bypass limit
+            local newres = table.deepcopy(res)
+            newres.amount = 65535
+            for n=1, math.floor(res.amount / 65535) do
+              recipe[dif].results[#recipe[dif].results+1] = newres
+            end
+            res.amount = res.amount % 65535
           end
         end
 			end


### PR DESCRIPTION
Includes the following:
- Fixes loss of crafting categories on compressed buildings (I honestly thought it was a feature, however it's actually a missing deepcopy)
- Add log when excluding items based on huge stack size
- Actually fix handling of outputs > 65535 by splitting into multiple "results"
- Adjust burner miner speed penalty so compressed versions aren't nonfunctional for omnite mining (still less efficient in ore/watt, and can't take modules vs electric miners, so they aren't an upgrade)