### PR TITLE
Fixing compatibility for 5dim new transport

### DIFF
--- a/omnimatter_energy/data-final-fixes.lua
+++ b/omnimatter_energy/data-final-fixes.lua
@@ -24,3 +24,9 @@ for _,rock in pairs(data.raw["simple-entity"]) do
         end
     end
 end
+
+if mods["5dim_transport"] then
+    -- Fixing the icon sizes back
+    data.raw["splitter"]["basic-splitter"]["structure_patch"]["west"]["hr_version"]["width"] = 90
+    data.raw["splitter"]["basic-splitter"]["structure"]["west"]["hr_version"]["width"] = 90
+end


### PR DESCRIPTION
Fixes the icon size issue in data-final-fixes. Not ideal, but works.
Probably the "real" fix would require 5dim to not pick up the basic-splitter up into their script.